### PR TITLE
Update Pipeline CRD to support starting point config

### DIFF
--- a/hadron-core/src/crd/mod.rs
+++ b/hadron-core/src/crd/mod.rs
@@ -11,7 +11,7 @@ mod token;
 
 use kube::Resource;
 
-pub use pipeline::{Pipeline, PipelineSpec, PipelineStage, PipelineStatus};
+pub use pipeline::{Pipeline, PipelineSpec, PipelineStage, PipelineStatus, PipelineStartPointLocation, PipelineStartPoint};
 pub use stream::{Stream, StreamSpec, StreamStatus};
 pub use token::{PubSubAccess, Token, TokenSpec, TokenStatus};
 

--- a/hadron-core/src/crd/pipeline.rs
+++ b/hadron-core/src/crd/pipeline.rs
@@ -38,6 +38,9 @@ pub struct PipelineSpec {
     /// The maximum number of pipeline instances which may be executed in parallel per partition.
     #[serde(rename = "maxParallel")]
     pub max_parallel: u32,
+    /// The starting point of the source stream from which to begin this pipeline.
+    #[serde(rename = "startPoint")]
+    pub start_point: PipelineStartPoint,
 }
 
 /// The definition of a Pipeline stage.
@@ -51,6 +54,28 @@ pub struct PipelineStage {
     /// All inputs (previous stages) which this stage depends upon in order to be started.
     #[serde(default)]
     pub dependencies: Vec<String>,
+}
+
+/// The starting point of the source stream from which to begin this pipeline.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
+pub struct PipelineStartPoint {
+    /// The start point location.
+    pub location: PipelineStartPointLocation,
+    /// The offset of the source stream from which to start this pipeline.
+    #[serde(default)]
+    pub offset: Option<u64>,
+}
+
+/// The starting point of the source stream from which to begin this pipeline.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum PipelineStartPointLocation {
+    /// The beginning of the source stream.
+    Beginning,
+    /// The most recent offset of the source stream.
+    Latest,
+    /// A specific offset of the source stream.
+    Offset,
 }
 
 /// CRD status object.

--- a/hadron-stream/proto/pipeline.proto
+++ b/hadron-stream/proto/pipeline.proto
@@ -2,18 +2,6 @@
 syntax = "proto2";
 package pipeline;
 
-// A pipeline instance.
-//
-// Pipeline instances are created when the source stream on the same partition receives a new
-// record which matches the pipeline's trigger criteria.
-message PipelineInstance {
-    // The ID of this object, which always corresponds to the offset of the source stream from
-    // which this instance was created.
-    required uint64 id = 1;
-    // The name of the parent pipeline object.
-    required string pipeline = 2;
-}
-
 // A pipeline stage output record.
 message PipelineStageOutput {
     // The ID of the pipeline instance with which this output is associated.

--- a/hadron-stream/src/models/pipeline.rs
+++ b/hadron-stream/src/models/pipeline.rs
@@ -10,8 +10,6 @@ pub use crate::models::proto::pipeline::*;
 /// An active pipeline instance along with all outputs from any completed stages.
 #[derive(Debug)]
 pub struct ActivePipelineInstance {
-    /// The model of the pipeline instance, directly from storage.
-    pub instance: PipelineInstance,
     /// A copy of the stream event which triggered this instance.
     pub root_event: Event,
     /// A copy of the raw bytes of the root event.

--- a/hadron-stream/src/models/proto/pipeline.rs
+++ b/hadron-stream/src/models/proto/pipeline.rs
@@ -1,17 +1,3 @@
-/// A pipeline instance.
-///
-/// Pipeline instances are created when the source stream on the same partition receives a new
-/// record which matches the pipeline's trigger criteria.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PipelineInstance {
-    /// The ID of this object, which always corresponds to the offset of the source stream from
-    /// which this instance was created.
-    #[prost(uint64, required, tag = "1")]
-    pub id: u64,
-    /// The name of the parent pipeline object.
-    #[prost(string, required, tag = "2")]
-    pub pipeline: ::prost::alloc::string::String,
-}
 /// A pipeline stage output record.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PipelineStageOutput {

--- a/k8s/helm/crds/pipeline.yaml
+++ b/k8s/helm/crds/pipeline.yaml
@@ -64,6 +64,25 @@ spec:
                       - name
                     type: object
                   type: array
+                startPoint:
+                  description: The starting point of the source stream from which to begin this pipeline.
+                  properties:
+                    location:
+                      description: The start point location.
+                      enum:
+                        - beginning
+                        - latest
+                        - offset
+                      type: string
+                    offset:
+                      description: The offset of the source stream from which to start this pipeline.
+                      format: uint64
+                      minimum: 0.0
+                      nullable: true
+                      type: integer
+                  required:
+                    - location
+                  type: object
                 triggers:
                   default: ""
                   description: "Event type matchers which will trigger this pipeline.\n\nValues are expressed as a comma-separated list. An empty string will match any event type."
@@ -72,6 +91,7 @@ spec:
                 - maxParallel
                 - sourceStream
                 - stages
+                - startPoint
               type: object
             status:
               description: CRD status object.

--- a/k8s/helm/examples/full.yaml
+++ b/k8s/helm/examples/full.yaml
@@ -22,6 +22,8 @@ spec:
   sourceStream: events
   triggers: ""
   maxParallel: 50
+  startPoint:
+    location: beginning
   stages:
     - name: deploy-service
 


### PR DESCRIPTION
This update allows pipelines to be created with a configuration which
controls the starting point of the source stream from which the pipeline
should begin processing.

A few efficiency improvements are added as well for encoding pipeline
metadata, storage of data models, and fixes an issue with recording of
active pipeline instances.

closes #68

