### PR TITLE
Add debug mode to Stream StatefulSet pods

### DIFF
--- a/hadron-core/src/crd/stream.rs
+++ b/hadron-core/src/crd/stream.rs
@@ -23,6 +23,7 @@ pub type Stream = StreamCRD; // Mostly to resolve a Rust Analyzer issue.
     printcolumn = r#"{"name":"Cluster Name","type":"string","jsonPath":".spec.cluster_name"}"#,
     printcolumn = r#"{"name":"Partitions","type":"number","jsonPath":".spec.partitions"}"#,
     printcolumn = r#"{"name":"TTL","type":"number","jsonPath":".spec.ttl"}"#,
+    printcolumn = r#"{"name":"Debug","type":"boolean","jsonPath":".spec.debug"}"#,
     printcolumn = r#"{"name":"PVC Volume Size","type":"string","jsonPath":".spec.pvc_volume_size"}"#,
     printcolumn = r#"{"name":"PVC Access Modes","type":"string","jsonPath":".spec.pvc_access_modes"}"#,
     printcolumn = r#"{"name":"PVC Storage Class","type":"string","jsonPath":".spec.pvc_storage_class"}"#
@@ -47,6 +48,9 @@ pub struct StreamSpec {
     /// restart of the stream's StatefulSet.
     #[serde(default)]
     pub ttl: u64,
+    /// Enable debug mode for the Stream's StatefulSet pods.
+    #[serde(default)]
+    pub debug: bool,
 
     /// Force an exact image to be used for the backing StatefulSet.
     ///

--- a/hadron-operator/src/k8s/scheduler.rs
+++ b/hadron-operator/src/k8s/scheduler.rs
@@ -456,6 +456,11 @@ impl Controller {
             match_labels: Some(labels.clone()),
             ..Default::default()
         };
+        let rust_log = if stream.spec.debug {
+            "error,hadron_stream=debug"
+        } else {
+            "error,hadron_stream=info"
+        };
         spec.template = PodTemplateSpec {
             metadata: Some(ObjectMeta { labels: Some(labels), ..Default::default() }),
             spec: Some(PodSpec {
@@ -485,7 +490,7 @@ impl Controller {
                     env: Some(vec![
                         EnvVar {
                             name: "RUST_LOG".into(),
-                            value: Some("error,hadron_stream=info".into()),
+                            value: Some(rust_log.into()),
                             ..Default::default()
                         },
                         EnvVar {

--- a/k8s/helm/crds/stream.yaml
+++ b/k8s/helm/crds/stream.yaml
@@ -24,6 +24,9 @@ spec:
         - jsonPath: ".spec.ttl"
           name: TTL
           type: number
+        - jsonPath: ".spec.debug"
+          name: Debug
+          type: boolean
         - jsonPath: ".spec.pvc_volume_size"
           name: PVC Volume Size
           type: string
@@ -44,6 +47,10 @@ spec:
                 cluster_name:
                   description: "The CloudEvents root `source` of all events of this cluster.\n\nThis value is used as the prefix of the `source` field of all events published to this stream, formatted as `{cluster_name}/{stream}/{partition}`.\n\nThis value can be re-used for any number of streams."
                   type: string
+                debug:
+                  default: false
+                  description: "Enable debug mode for the Stream's StatefulSet pods."
+                  type: boolean
                 image:
                   description: "Force an exact image to be used for the backing StatefulSet.\n\nNormally this will should not be set, and the Operator will ensure that the most recent semver compatible image is being used."
                   type: string

--- a/k8s/helm/examples/full.yaml
+++ b/k8s/helm/examples/full.yaml
@@ -7,6 +7,7 @@ spec:
   cluster_name: "example.hadron.rs"
   partitions: 3
   ttl: 0
+  debug: true
   image: "ghcr.io/hadron-project/hadron/hadron-stream:latest"
   pvc_volume_size: "5Gi"
   pvc_access_modes:


### PR DESCRIPTION
The Stream spec has been updated with a `debug: bool` field. When
`true`, the Stream's backing StatefulSet will have its pods configured
to use debug level logging.

closes #77

